### PR TITLE
feat(sdk): implement device service calls for device control

### DIFF
--- a/custom_components/azoula_smart/sdk/const.py
+++ b/custom_components/azoula_smart/sdk/const.py
@@ -66,8 +66,9 @@ DEVICE_CAPABILITIES = {
 METHOD_DEVICE_ONLINE = "thing.device.online"
 METHOD_DEVICE_OFFLINE = "thing.device.offline"
 METHOD_PROPERTY_POST = "thing.device.propPost"
-METHOD_EVENT_POST = "thing.device.eventPost"
-METHOD_PROPERTY_SET = "thing.device.propSet"
-METHOD_SERVICE_CALL = "thing.device.serviceCall"
 METHOD_GET_ALL_DEVICES = "thing.subdev.getall"
 METHOD_GET_ALL_DEVICES_REPLY = "thing.subdev.getall.reply"
+
+# Service call methods (from protocol doc)
+METHOD_SERVICE = "thing.service"
+METHOD_SERVICE_REPLY = "thing.service.reply"


### PR DESCRIPTION
## Summary
- Implement proper device service calls using `thing.service` protocol as per Azoula documentation
- Replace incorrect property-based control with service-based control for switches/lights
- Add `call_device_service()` method to support OnOffClusterOn/Off/Toggle operations
- Clean up SDK by removing unused property setting methods and constants

## Changes Made
- **SDK Enhancement**: Add `call_device_service()` method to `AzoulaSmartHub` class
- **Protocol Compliance**: Use correct `thing.service` payload format with proper identifier and params structure  
- **Code Cleanup**: Remove `set_device_properties()` method and unused protocol constants
- **Test Improvements**: Update test script to use service calls and auto-detect first online device
- **Validation**: All 3 service calls (On/Off/Toggle) now working correctly with 200 responses

## Test Results
```
Control test completed: 3/3 commands succeeded
✓ All device control commands succeeded!
```

## Test plan
- [x] Service calls send correct MQTT messages to gateway
- [x] Gateway responds with 200 success codes
- [x] Device actually changes state (confirmed via property events)
- [x] Code passes ruff linting and mypy type checking
- [x] Test script works with any online device (not hardcoded)